### PR TITLE
fix api key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 stages:
-  - name: test
-  - name: Build & Post on GitHub
-    if: branch = master
+- name: test
+- name: Build & Post on GitHub
+  if: branch = master
 jobs:
   include:
   - stage: test
@@ -9,30 +9,26 @@ jobs:
     php: '7.1'
     os: linux
     before_script:
-      - composer install
+    - composer install
   - stage: test
     language: node_js
     node_js: '9'
     before_install:
-      - yarn global add grunt-cli
+    - yarn global add grunt-cli
   - stage: Build & Post on GitHub
     language: php
     php: '7.1'
     before_script:
-      - composer install
-      - cd package
+    - composer install
+    - cd package
     script:
-      - "./pack.php -v $(date +'%Y%m%d-%H.%M.%S')"
-      - "./pack.php -v $(date +'%Y%m%d-%H.%M.%S') -w 40" #Using 40 as a typical path length. May not work for all Windows installations
-    before_deploy:
-      git tag "$(date +'%Y%m%d-%H.%M.%S')-$(git log --format=%h -1)"
+    - "./pack.php -v $(date +'%Y%m%d-%H.%M.%S')"
+    - "./pack.php -v $(date +'%Y%m%d-%H.%M.%S') -w 40" #Using 40 as a typical path length. May not work for all Windows installations
+    before_deploy: git tag "$(date +'%Y%m%d-%H.%M.%S')-$(git log --format=%h -1)"
     deploy:
       file_glob: true
       provider: releases
-      file:
-        - releases/sugarcrm-ProfessorM-*-standard.zip
-        - releases/sugarcrm-ProfessorM-*-windows.zip
-        - releases/sugarcrm-ProfessorM-*-windows-manual-install.zip
+      file: releases/sugarcrm-ProfessorM-*.zip
       api_key:
-          secure: bM9iT8Lh06t/BKWDHZpTKrsE3UQqs1EnPWkNy6+KqXCuaECeeyw9KlvkVfhsDgXH4a9g2RvnIkXwWuueOZvLEHeAdaVxC0JpP2Zbv4kBcF8LOuRKaJVCrjcnnPGQft2F5wKdnEbXPd4ZjSK40kSk8qSp3cSjMUYrVFwcttmvTY08sbNN2Tbx/zelkTELmOKWj+1QseNr6ch7r9PrzR2GvK6p6QJUFmMXyIDywlUvCdFafjc4pikhhuTq/1gdUARyC8+pTSb70atP53PoKZtVcHXL1l+Jis7DxWAN/fVy+Fsv5yeLbXsj8M4xc5Uzy3TltAaIVLUSpOAU9KaKvJREkCy1V42ha10c5NSlkZ9jxI7XlPfiqVgKZB0bR9MAD+6sUYBF9gQvVfAJUztFCoLdPtMnmvVuhCY94t9hBc6WJbeldd6/aBy8NPAD2QZ3ZMeJ65m3PnboMPtnychhGGF+c4sU/Wmtz4ptUG0qe1ajEV/mX7chr5lWWHySdr41BwklcIm0ZSMmtI4lwZgUIMVkjowd3abWovN8OQg4i9AcvGyutfIANH+SQF357GfshzYSvUZ50E7uYeKrMjK0bqZJH/Gbw6WElQb7w88P0sCnpzb944ssXtl/zBCpW7zg6bBZCo+1E8wp8BWwqLj+li1F3Gn0kqEVoKgz+gjazkIqwmU=
+        secure: wZjieCCyLewnTuR1vLjtVLp+ANtaq2ltP6kyiBcE33j2WyyWIiQqHtmjWAnnpq3Kkz64Pe1epfWuFJagXQyMvH9ACojmk0bZmbJjt293g7YWVVHOVco69Ti9+D4bTuHNeWIS31xbDTdzgiz/t9c2dVt8ISLFsIG7GJUsg3P+ye+GH/zbmPmrcmyMLnEtlymOSvbg1RiCQ9AJyUywLenes1Un/2nZuJpkZ76KwwnQNHH6xF1iIRtbR41/B1nRKiJgsArfz1FQp5sM6naOZiqnGejuQ8LswxYGbWZM27iJblW+NpTWJrvNswGEekEb63mVGIx3VJjEGKqkD1cjOYmaGG6nenSEI55r6BTEtoa9zV02pjQ8MMBaX5gPftvnmDrHGqwS7vtqM1YjJ8M0dWhkNqmz4fvss+IuPveaYNyHHeytQElhSuOoS0BAJsq7q3eZbK+Wj7Nd6qnXbJ6zJtuounljG9Kz9bmP82HUA04xn5lSpIIfi+KSb8CiQfzzRf2iws8wpfZ5fAU8OxImuEDaWRjH7473Uyr05Ai4v8d9gx9RmHhjJngOpjyJ4QekHRMmxO3m3msmhEkNjDq+9eM6pQDadwbnQtYTaTSyVXmq8UmV54sqhj8ZRskFmYlqEeM5b0qi+VujREykfnY4a5uJyxXOFLMlAP8HRUK3JGRX3kE=
       skip_cleanup: true


### PR DESCRIPTION
Fix for Issue #13 

API key was no longer valid after we moved from travis-ci.com to travis-ci.org.  To fix, I followed steps in https://docs.travis-ci.com/user/travis-pro#How-can-I-make-a-private-repository-public%3F.  Also, had to generate a new key with the org flag: 
travis setup releases --org