### PR TITLE
Fix license tag in composer.json

### DIFF
--- a/package/composer.json
+++ b/package/composer.json
@@ -6,7 +6,7 @@
         "phpunit/phpunit": "^6.5",
         "mikey179/vfsstream": "^1.6"
     },
-    "license": "Apache-2",
+    "license": "Apache-2.0",
     "authors": [
         {
             "name": "SugarCRM Developer Advocacy",


### PR DESCRIPTION
The preferred format for specifying the Apache license is "Apache-2.0"; see https://getcomposer.org/doc/04-schema.md#license